### PR TITLE
Update examples and add Function.prototype.extend polyfill

### DIFF
--- a/examples/experiment_verification.js
+++ b/examples/experiment_verification.js
@@ -1,54 +1,53 @@
 var express = require('express');
 var app = express();
-
 var planout = require('../dist/planout.js');
+var extend = require('./polyfills/extend.js');
 
-var Experiment1 = function(args) {
-  var experiment = new planout.Experiment(args);
-  experiment.setup = function() { this.setSalt("Exp1"); }
-  experiment.setup();
-  experiment.assign = function(params, args) {
+var Experiment1 = planout.Experiment.extend({
+  setup: function() {
+    this.setName("Exp1");
+    this.setSalt("Exp1");
+  },
+  assign: function(params, args) {
     params.set('group_size', new planout.Ops.Random.UniformChoice({ 'choices': [1, 10], 'unit': args.userid}));
     params.set('specific_goal', new planout.Ops.Random.BernoulliTrial({'p': 0.8, 'unit': args.userid}));
     if (params.get('specific_goal')) {
       params.set('ratings_per_user_goal', new planout.Ops.Random.UniformChoice({ 'choices': [8, 16, 32, 64], 'unit': args.userid}));
       params.set('ratings_goal', params.get('group_size') * params.get('ratings_per_user_goal'));
     }
-  };
-  experiment.getParamNames = function() { return this.getDefaultParamNames(); }
-  experiment.configureLogger = function() { return; }
-  experiment.log = function(stuff) { return; }
-  experiment.previouslyLogged = function() { return; }
-  return experiment;
-};
+  },
+  getParamNames: function() { return this.getDefaultParamNames(); },
+  configureLogger: function() { return; },
+  log: function(stuff) { return; },
+  previouslyLogged: function() { return; },
+});
 
-var Experiment3 = function(args) {
-  var experiment = new planout.Experiment(args);
-  experiment.setup = function() { this.setSalt("Exp3"); }
-  experiment.setup();
-  experiment.assign = function(params, args) {
+var Experiment3 = planout.Experiment.extend({
+  setup: function() {
+    this.setName("Exp3");
+    this.setSalt("Exp3");
+  },
+  assign: function(params, args) {
     params.set('has_banner', new planout.Ops.Random.BernoulliTrial({ 'p': 0.97, 'unit': args.userid}));
     var cond_probs = [0.5, 0.95];
     params.set('has_feed_stories', new planout.Ops.Random.BernoulliTrial({'p': cond_probs[params.get('has_banner')], 'unit': args.userid}));
     params.set('button_text', new planout.Ops.Random.UniformChoice({'choices': ["I'm a voter", "I'm voting"], 'unit': args.userid}))
-  };
-  experiment.getParamNames = function() { return this.getDefaultParamNames(); }
-  experiment.configureLogger = function() { return; }
-  experiment.log = function(stuff) { return; }
-  experiment.previouslyLogged = function() { return; }
-  return experiment;
-
-}
+  },
+  getParamNames: function() { return this.getDefaultParamNames(); },
+  configureLogger: function() { return; },
+  log: function(stuff) { return; },
+  previouslyLogged: function() { return; },
+});
 
 var experiment1_results = [];
 for (var i = 0; i < 10; i++) {
-  var exp = Experiment1({'userid': i});
+  var exp = new Experiment1({'userid': i});
   experiment1_results.push([exp.get('group_size'), exp.get('ratings_goal')]);
 }
 
 var experiment3_results = [];
 for (var i =0 ; i < 5; i++) {
-  var exp = Experiment3({'userid': i});
+  var exp = new Experiment3({'userid': i});
   experiment3_results.push([exp.get('button_text')]);
 }
 

--- a/examples/polyfills/extend.js
+++ b/examples/polyfills/extend.js
@@ -1,0 +1,33 @@
+/* This is basically a way to easily extend classes in ES5 - source: https://gist.github.com/juandopazo/1367191 */
+Object.getOwnPropertyDescriptors = function getOwnPropertyDescriptors(obj) {
+  var descriptors = {};
+  for (var prop in obj) {
+    if (obj.hasOwnProperty(prop)) {
+      descriptors[prop] = Object.getOwnPropertyDescriptor(obj, prop);
+    }
+  }
+  return descriptors;
+};
+
+Function.prototype.extend = function extend(proto) {
+    var superclass = this;
+    var constructor;
+
+    if (!proto.hasOwnProperty('constructor')) {
+      Object.defineProperty(proto, 'constructor', {
+        value: function () {
+            // Default call to superclass as in maxmin classes
+            superclass.apply(this, arguments);
+        },
+        writable: true,
+        configurable: true,
+        enumerable: false
+      });
+    }
+    constructor = proto.constructor;
+
+    constructor.prototype = Object.create(this.prototype, Object.getOwnPropertyDescriptors(proto));
+
+    return constructor;
+};
+/* End extend helper */

--- a/examples/sample_interpreter_es5.js
+++ b/examples/sample_interpreter_es5.js
@@ -1,42 +1,8 @@
 var express = require('express');
 var app = express();
 var planout = require('../dist/planout.js');
+var extend = require('./polyfills/extend.js');
 
-/* This is basically a way to easily extend classes in ES5 - source: https://gist.github.com/juandopazo/1367191 */
-Object.getOwnPropertyDescriptors = function getOwnPropertyDescriptors(obj) {
-  var descriptors = {};
-  for (var prop in obj) {
-    if (obj.hasOwnProperty(prop)) {
-      descriptors[prop] = Object.getOwnPropertyDescriptor(obj, prop);
-    }
-  }
-  return descriptors;
-};
- 
-Function.prototype.extend = function extend(proto) {
-    var superclass = this;
-    var constructor;
- 
-    if (!proto.hasOwnProperty('constructor')) {
-      Object.defineProperty(proto, 'constructor', {
-        value: function () {
-            // Default call to superclass as in maxmin classes
-            superclass.apply(this, arguments);
-        },
-        writable: true,
-        configurable: true,
-        enumerable: false
-      });
-    }
-    constructor = proto.constructor;
-    
-    constructor.prototype = Object.create(this.prototype, Object.getOwnPropertyDescriptors(proto));
-    
-    return constructor;
-};
-
-
-/* End extend helper */
 
 var compiledScript = {"op":"seq",
        "seq": [
@@ -56,7 +22,7 @@ var compiledScript = {"op":"seq",
     };
 
 /* Using this class the experiment serialization is passed down to the class at initialization, presumably because
-   it's been loaded with all other experiment definitions using a network request where you only want to make a one time request 
+   it's been loaded with all other experiment definitions using a network request where you only want to make a one time request
    for all currently running experiments and lazily evaluate them as needed. This approach works well for client-side apps.
 */
 var LazyInterpretedExperiment = planout.Interpreter.extend({
@@ -111,7 +77,7 @@ var EagerInterpretedExperiment = planout.Experiment.extend({
   setup: function() {
     this.name = "SampleExperiment";
   },
-  loadScript: function() { 
+  loadScript: function() {
 
     /* here you can read from the database, filesystem, etc. */
     return compiledScript;

--- a/examples/sample_planout_es5.js
+++ b/examples/sample_planout_es5.js
@@ -1,42 +1,7 @@
 var express = require('express');
 var app = express();
 var planout = require('../dist/planout.js');
-
-
-/* This is basically a way to easily extend classes in ES5 - source: https://gist.github.com/juandopazo/1367191 */
-Object.getOwnPropertyDescriptors = function getOwnPropertyDescriptors(obj) {
-  var descriptors = {};
-  for (var prop in obj) {
-    if (obj.hasOwnProperty(prop)) {
-      descriptors[prop] = Object.getOwnPropertyDescriptor(obj, prop);
-    }
-  }
-  return descriptors;
-};
- 
-Function.prototype.extend = function extend(proto) {
-    var superclass = this;
-    var constructor;
- 
-    if (!proto.hasOwnProperty('constructor')) {
-      Object.defineProperty(proto, 'constructor', {
-        value: function () {
-            // Default call to superclass as in maxmin classes
-            superclass.apply(this, arguments);
-        },
-        writable: true,
-        configurable: true,
-        enumerable: false
-      });
-    }
-    constructor = proto.constructor;
-    
-    constructor.prototype = Object.create(this.prototype, Object.getOwnPropertyDescriptors(proto));
-    
-    return constructor;
-};
-
-/* End extend helper */
+var extend = require('./polyfills/extend.js');
 
 var DummyExperiment = planout.Experiment.extend({
   setup: function() {


### PR DESCRIPTION
- Fixes a [bug](https://github.com/HubSpot/PlanOut.js/issues/63) introduced into our express examples by https://github.com/HubSpot/PlanOut.js/pull/59
- Adds ```Function.prototype.extend``` polyfill outside of examples in an attempt to minimize distractions from actual example code.

Thank you for pointing this out @ckuijjer!

---
@rawls238 @geoffdaigle 

